### PR TITLE
Bake in linker

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,14 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/oxidize-rb/x86_64-linux:3.2-ubuntu"
+
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/oxidize-rb/x86_64-linux-musl:3.2-ubuntu"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/oxidize-rb/aarch64-linux:3.2-ubuntu"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/oxidize-rb/aarch64-linux-musl:3.2-ubuntu"
+
+[target.arm-unknown-linux-gnueabihf]
+image = "ghcr.io/oxidize-rb/arm-linux:3.2-ubuntu"

--- a/docker/builds/aarch64-linux-musl/Dockerfile
+++ b/docker/builds/aarch64-linux-musl/Dockerfile
@@ -65,12 +65,10 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-# Our openssl cannot find the system CA certs, so we use mkcert to pull
-# Mozilla's CA certs
-RUN set -ex; \
-    mkdir -p /opt/_internal/ssl/; \
-    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
-ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
+COPY docker/scripts/install-root-cert.sh /
+RUN /install-root-certs.sh
 
-COPY /docker/scripts/cleanup.sh /cleanup.sh
+COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/aarch64-linux-musl/Dockerfile
+++ b/docker/builds/aarch64-linux-musl/Dockerfile
@@ -67,6 +67,7 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
 RUN /install-root-cert.sh
+ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/aarch64-linux-musl/Dockerfile
+++ b/docker/builds/aarch64-linux-musl/Dockerfile
@@ -66,7 +66,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-certs.sh
+RUN /install-root-cert.sh
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/aarch64-linux-musl/Dockerfile
+++ b/docker/builds/aarch64-linux-musl/Dockerfile
@@ -31,6 +31,7 @@ COPY docker/pkg/ /opt/_internal/pkg/
 
 RUN set -ex; \
     /opt/_internal/pkg/install --install-dir /usr/local --cross-target native \
+      libclang \
       patchelf; \
     /opt/_internal/pkg/install \
       zlib \

--- a/docker/builds/aarch64-linux/Dockerfile
+++ b/docker/builds/aarch64-linux/Dockerfile
@@ -30,6 +30,7 @@ COPY docker/scripts/build-ruby.sh /
 
 RUN set -ex; \
     /opt/_internal/pkg/install --install-dir /usr/local --cross-target native \
+      libclang \
       patchelf; \
     /opt/_internal/pkg/install \
       zlib \
@@ -63,11 +64,14 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-cert.sh
+# Our openssl cannot find the system CA certs, so we use mkcert to pull
+# Mozilla's CA certs
+RUN set -ex; \
+    mkdir -p /opt/_internal/ssl/; \
+    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
 ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
-COPY docker/scripts/cleanup.sh /cleanup.sh
+COPY /docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/aarch64-linux/Dockerfile
+++ b/docker/builds/aarch64-linux/Dockerfile
@@ -64,7 +64,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-certs.sh
+RUN /install-root-cert.sh
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/aarch64-linux/Dockerfile
+++ b/docker/builds/aarch64-linux/Dockerfile
@@ -65,6 +65,7 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
 RUN /install-root-cert.sh
+ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/aarch64-linux/Dockerfile
+++ b/docker/builds/aarch64-linux/Dockerfile
@@ -63,12 +63,10 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-# Our openssl cannot find the system CA certs, so we use mkcert to pull
-# Mozilla's CA certs
-RUN set -ex; \
-    mkdir -p /opt/_internal/ssl/; \
-    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
-ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
+COPY docker/scripts/install-root-cert.sh /
+RUN /install-root-certs.sh
 
-COPY /docker/scripts/cleanup.sh /cleanup.sh
+COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/arm-linux/Dockerfile
+++ b/docker/builds/arm-linux/Dockerfile
@@ -30,6 +30,7 @@ COPY docker/scripts/build-ruby.sh /
 
 RUN set -ex; \
     /opt/_internal/pkg/install --install-dir /usr/local --cross-target native \
+      libclang \
       patchelf; \
     /opt/_internal/pkg/install \
       zlib \

--- a/docker/builds/arm-linux/Dockerfile
+++ b/docker/builds/arm-linux/Dockerfile
@@ -65,7 +65,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-certs.sh
+RUN /install-root-cert.sh
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/arm-linux/Dockerfile
+++ b/docker/builds/arm-linux/Dockerfile
@@ -66,6 +66,7 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
 RUN /install-root-cert.sh
+ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/arm-linux/Dockerfile
+++ b/docker/builds/arm-linux/Dockerfile
@@ -64,12 +64,10 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-# Our openssl cannot find the system CA certs, so we use mkcert to pull
-# Mozilla's CA certs
-RUN set -ex; \
-    mkdir -p /opt/_internal/ssl/; \
-    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
-ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
+COPY docker/scripts/install-root-cert.sh /
+RUN /install-root-certs.sh
 
-COPY /docker/scripts/cleanup.sh /cleanup.sh
+COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
+
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/x86_64-linux-musl/Dockerfile
+++ b/docker/builds/x86_64-linux-musl/Dockerfile
@@ -64,7 +64,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-certs.sh
+RUN /install-root-cert.sh
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/x86_64-linux-musl/Dockerfile
+++ b/docker/builds/x86_64-linux-musl/Dockerfile
@@ -63,12 +63,10 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-# Our openssl cannot find the system CA certs, so we use mkcert to pull
-# Mozilla's CA certs
-RUN set -ex; \
-    mkdir -p /opt/_internal/ssl/; \
-    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
-ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
+COPY docker/scripts/install-root-cert.sh /
+RUN /install-root-certs.sh
 
-COPY /docker/scripts/cleanup.sh /cleanup.sh
+COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
+
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/x86_64-linux-musl/Dockerfile
+++ b/docker/builds/x86_64-linux-musl/Dockerfile
@@ -65,6 +65,7 @@ RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
 COPY docker/scripts/install-root-cert.sh /
 RUN /install-root-cert.sh
+ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
 COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh

--- a/docker/builds/x86_64-linux-musl/Dockerfile
+++ b/docker/builds/x86_64-linux-musl/Dockerfile
@@ -29,6 +29,7 @@ COPY docker/scripts/build-ruby.sh /
 
 RUN set -ex; \
     /opt/_internal/pkg/install --install-dir /usr/local --cross-target native \
+      libclang \
       patchelf; \
     /opt/_internal/pkg/install \
       zlib \

--- a/docker/builds/x86_64-linux/Dockerfile
+++ b/docker/builds/x86_64-linux/Dockerfile
@@ -61,6 +61,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
 
 COPY docker/scripts/install-root-cert.sh /
 RUN /install-root-cert.sh
+ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
 
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"

--- a/docker/builds/x86_64-linux/Dockerfile
+++ b/docker/builds/x86_64-linux/Dockerfile
@@ -59,15 +59,13 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
     BUNDLE_APP_CONFIG="$GEM_HOME" \
     RUBY_VERSION="$RUBY_VERSION"
 
-# Our openssl cannot find the system CA certs, so we use mkcert to pull
-# Mozilla's CA certs
-RUN set -ex; \
-    mkdir -p /opt/_internal/ssl/; \
-    curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/;
-ENV SSL_CERT_FILE "/opt/_internal/ssl/certifi.pem"
+COPY docker/scripts/install-root-cert.sh /
+RUN /install-root-certs.sh
 
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
 
-COPY /docker/scripts/cleanup.sh /cleanup.sh
+COPY docker/scripts/cleanup.sh /cleanup.sh
 RUN /cleanup.sh
+
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="${CROSS_TOOLCHAIN_PREFIX}gcc"

--- a/docker/builds/x86_64-linux/Dockerfile
+++ b/docker/builds/x86_64-linux/Dockerfile
@@ -60,7 +60,7 @@ ENV PATH="$GEM_HOME/bin:$RUBY_ROOT/bin:$PATH" \
     RUBY_VERSION="$RUBY_VERSION"
 
 COPY docker/scripts/install-root-cert.sh /
-RUN /install-root-certs.sh
+RUN /install-root-cert.sh
 
 # adjust permissions of a few directories for running "gem install" as an arbitrary user
 RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"

--- a/docker/builds/x86_64-linux/Dockerfile
+++ b/docker/builds/x86_64-linux/Dockerfile
@@ -29,6 +29,7 @@ COPY docker/scripts/build-ruby.sh /
 
 RUN set -ex; \
     /opt/_internal/pkg/install --install-dir /usr/local --cross-target native \
+      libclang \
       patchelf; \
     /opt/_internal/pkg/install \
       zlib \

--- a/docker/pkg/install
+++ b/docker/pkg/install
@@ -47,7 +47,7 @@ main() {
 
   cd "$build_dir"
   log "Fetching $name-$version"
-  fetch_source_and_verify "$source" "$srcdir" "$sha256"
+  fetch_source_and_verify "$source" "$sha256"
 
   cd "$build_dir"
   log "Building $name-$version"
@@ -87,8 +87,8 @@ abort () {
 
 fetch_source_and_verify() {
     local url="$1"
-    local file="$2.tar.gz"
-    local sha256="$3"
+    local file="${url##*/}"
+    local sha256="$2"
 
     log "Downloading $url"
     curl --retry 5 -fsSLo "$file" "$url"
@@ -100,6 +100,7 @@ fetch_source_and_verify() {
       exit 1
     fi
 
+    log "Unpacking $file"
     tar -xf "$file"
     rm "$file"
 }

--- a/docker/pkg/libclang.sh
+++ b/docker/pkg/libclang.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+# shellcheck disable=SC2154
+
+export name="libclang"
+export version="14.0.6"
+
+case "$cross_target" in
+  x86_64*)
+    export sha256="83322ab57db18f3dc306a0b15f95fed3728250430b4de433c1a871cb61b51e64"
+    pkg_arch="x86_64-linux"
+    ;;
+  aarch64*)
+    export sha256="7e3d975f75caf0f6cf5d2bf1f631a95b80382d073784ed52c04bb0cab7d37ab0"
+    pkg_arch="aarch64-linux"
+    ;;
+  *)
+    abort "Unsupported target: $cross_target"
+    ;;
+esac
+
+export source="https://rubygems.org/downloads/libclang-$version-$pkg_arch.gem"
+export srcdir="$name-$version-$pkg_arch"
+
+build() {
+  tar -xzf data.tar.gz
+}
+
+check() {
+  test -f vendor/lib/libclang.so
+}
+
+install() {
+  for lib in vendor/lib/*; do
+    cp "$lib" "$install_dir/lib"
+  done
+}

--- a/docker/scripts/install-root-cert.sh
+++ b/docker/scripts/install-root-cert.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Our openssl cannot find the system CA certs, so we use mkcert to pull
+# Mozilla's CA certs
+main() {
+  mkdir -p /opt/_internal/ssl/
+  curl --retry 3 -o "/opt/_internal/ssl/certifi.pem" -sSL https://mkcert.org/generate/
+  rm -rf "${0}"
+}
+
+main "$@"


### PR DESCRIPTION
This PR instructs cargo to use the crosstools linker by default, so that linking libruby works in all cases. Also, we bundle in libclang (via [libclang-rb](https://github.com/oxidize-rb/libclang-rb) so bindgen will always work.